### PR TITLE
Overlay and Genealogy Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,28 @@ The following constants can be imported from `maltego_trx.maltego`.
 - `LINK_STYLE_DOTTED`
 - `LINK_STYLE_DASHDOT`
 
+### Enums
+
+**Overlays:**
+
+Overlays Enums are imported from `maltego_trx.overlays`
+
+*Overlay Position:*
+- `NORTH = "N"`
+- `NORTH_EAST = "NE"`
+- `NORTH_WEST = "NW"`
+- `EAST = "E"`
+- `CENTER = "C"`
+- `WEST = "W"`
+- `SOUTH = "S"`
+- `SOUTH_EAST = "SE"`
+- `SOUTH_WEST = "SW"`
+
+*Overlay Type*
+- `IMAGE = "image"`
+- `COLOUR = "colour"`
+- `TEXT = "text"`
+
 ### Request/MaltegoMsg
 
 The request/maltego msg object given to the transform contains the information about the input entity.
@@ -213,6 +235,8 @@ The request/maltego msg object given to the transform contains the information a
 - `Type: str`: The input entity type
 - `Properties: dict(str: str)`: A key-value dictionary of the input entity properties
 - `TransformSettings: dict(str: str)`: A key-value dictionary of the transform settings
+- `Genealogy: list(dict(str: str))`: A key-value dictionary of the Entity genealogy, 
+    this is only applicable for extended entities e.g. Website Entity
 
 **Methods:**
 
@@ -235,9 +259,32 @@ The request/maltego msg object given to the transform contains the information a
 - `setWeight(weight: int)`: Set the entity weight
 - `addDisplayInformation(content: str, title: str)`: Add display information for the entity.
 - `addProperty(fieldName: str, displayName: str, matchingRule: str, value: str)`: Add a property to the entity. Matching rule can be `strict` or `loose`.
+- `addOverlay(property_name: str, position:Position, overlay_type:OverlayType)`: Add an overlay to the entity. `Position` and `Type` are defined in the `maltego_tx.overlays`
+
+Overlay can be added as Text, Image or Color
+
+```python 
+        
+        # references the icon name `Champion` from the Maltego Desktop Client and this is will show up as an overlay on the graph
+        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+
+        # add a dynamic property 
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+
+        # add the text value of the property `exampleDynamicPropertyName` as an overlay, any existing property name will work
+        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+
+        # add a color overlay
+        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+
+        # add a flag overlay - DE is an icon on the Maltego Desktop Client
+        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)
+```
+
 - `setIconURL(url: str)`: Set the entity icon URL
 - `setBookmark(bookmark: int)`: Set bookmark color index (e.g. -1 for BOOKMARK_COLOR_NONE, 3 for BOOKMARK_COLOR_PURPLE)
 - `setNote(note: str)`: Set note content
+- `setGenealogy(genealogy: dict)`: Set genealogy
 
 **Link Methods:**
 

--- a/demo/apache/transforms/OverlayExample.py
+++ b/demo/apache/transforms/OverlayExample.py
@@ -1,5 +1,5 @@
 from maltego_trx.entities import Phrase
-from maltego_trx.overlays import Position, OverlayType
+from maltego_trx.overlays import OverlayPosition, OverlayType
 
 from maltego_trx.transform import DiscoverableTransform
 
@@ -14,17 +14,23 @@ class OverlayExample(DiscoverableTransform):
         person_name = request.Value
         entity = response.addEntity(Phrase, "Hi %s, nice to meet you!" % person_name)
 
-        # references the icon name `Champion` and this is will show up as an overlay on the graph
-        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+        # Normally, when we create an overlay, we would reference a property name so that Maltego can then use the
+        # value of that property to create the overlay. Sometimes that means creating a dynamic property, but usually
+        # it's better to either use an existing property, or, if you created the Entity yourself, and only need the
+        # property for the overlay, to use a hidden property. Here's an example of using a dynamic property:
+        entity.addProperty('dynamic_overlay_icon_name', displayName="Name for overlay image", value="Champion")
+        entity.addOverlay('dynamic_overlay_icon_name', OverlayPosition.WEST, OverlayType.IMAGE)
 
-        # addProperty(self, fieldName=None, displayName=None, matchingRule='loose', value=None):
-        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+        # DISCOURAGED:
+        # You *can* also directly supply the string value of the property, however this is not recommended. Why? If
+        # the entity already has a property of the same ID (in this case, "DE"), then you would in fact be assigning the
+        # value of that property, not the string "DE", which is not the intention. Nevertheless, here's an example:
+        entity.addOverlay('DE', OverlayPosition.SOUTH_WEST, OverlayType.IMAGE)
 
-        # add the text of the property `exampleDynamicPropertyName` as an overlay
-        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+        # Overlays can also be used to display extra text on an entity:
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Overlay Testing")
+        entity.addOverlay('exampleDynamicPropertyName', OverlayPosition.NORTH, OverlayType.TEXT)
 
-        # add a color overlay
-        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+        # Or a small color indicator:
+        entity.addOverlay('#45e06f', OverlayPosition.NORTH_WEST, OverlayType.COLOUR)
 
-        # add a flag overlay
-        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)

--- a/demo/apache/transforms/OverlayExample.py
+++ b/demo/apache/transforms/OverlayExample.py
@@ -1,0 +1,30 @@
+from maltego_trx.entities import Phrase
+from maltego_trx.overlays import Position, OverlayType
+
+from maltego_trx.transform import DiscoverableTransform
+
+
+class OverlayExample(DiscoverableTransform):
+    """
+    Returns a phrase with overlays on the graph.
+    """
+
+    @classmethod
+    def create_entities(cls, request, response):
+        person_name = request.Value
+        entity = response.addEntity(Phrase, "Hi %s, nice to meet you!" % person_name)
+
+        # references the icon name `Champion` and this is will show up as an overlay on the graph
+        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+
+        # addProperty(self, fieldName=None, displayName=None, matchingRule='loose', value=None):
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+
+        # add the text of the property `exampleDynamicPropertyName` as an overlay
+        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+
+        # add a color overlay
+        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+
+        # add a flag overlay
+        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)

--- a/demo/gunicorn/Dockerfile
+++ b/demo/gunicorn/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /var/www/TRX/
 WORKDIR /var/www/TRX/
 
 # System dependencies
-RUN apt-get update
+RUN apt-get update -y
 RUN apt-get install python3-pip -y
 
 COPY requirements.txt requirements.txt
@@ -18,4 +18,5 @@ COPY . /var/www/TRX/
 
 RUN chown -R www-data:www-data /var/www/TRX/
 
+# for running a production server, use docker-compose with prod.yml or prod-ssl.yml
 CMD ["python3", "project.py", "runserver"]

--- a/demo/gunicorn/prod-ssl.yml
+++ b/demo/gunicorn/prod-ssl.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  python:
+    build: .
+    command: "gunicorn --certfile=server.crt --keyfile=server.key --bind=0.0.0.0:8443 --threads=25 --workers=2 project:app"
+    ports:
+       - "8443:8443"

--- a/demo/gunicorn/prod.yml
+++ b/demo/gunicorn/prod.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   python:
-    build: ..
+    build: .
     command: "gunicorn --bind=0.0.0.0:8080 --threads=25 --workers=2 project:app"
     ports:
        - "8080:8080"

--- a/demo/gunicorn/requirements.txt
+++ b/demo/gunicorn/requirements.txt
@@ -1,1 +1,1 @@
-maltego-trx
+maltego-trx>=1.3.8

--- a/demo/gunicorn/transforms/OverlayExample.py
+++ b/demo/gunicorn/transforms/OverlayExample.py
@@ -1,5 +1,5 @@
 from maltego_trx.entities import Phrase
-from maltego_trx.overlays import Position, OverlayType
+from maltego_trx.overlays import OverlayPosition, OverlayType
 
 from maltego_trx.transform import DiscoverableTransform
 
@@ -14,17 +14,23 @@ class OverlayExample(DiscoverableTransform):
         person_name = request.Value
         entity = response.addEntity(Phrase, "Hi %s, nice to meet you!" % person_name)
 
-        # references the icon name `Champion` and this is will show up as an overlay on the graph
-        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+        # Normally, when we create an overlay, we would reference a property name so that Maltego can then use the
+        # value of that property to create the overlay. Sometimes that means creating a dynamic property, but usually
+        # it's better to either use an existing property, or, if you created the Entity yourself, and only need the
+        # property for the overlay, to use a hidden property. Here's an example of using a dynamic property:
+        entity.addProperty('dynamic_overlay_icon_name', displayName="Name for overlay image", value="Champion")
+        entity.addOverlay('dynamic_overlay_icon_name', OverlayPosition.WEST, OverlayType.IMAGE)
 
-        # addProperty(self, fieldName=None, displayName=None, matchingRule='loose', value=None):
-        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+        # DISCOURAGED:
+        # You *can* also directly supply the string value of the property, however this is not recommended. Why? If
+        # the entity already has a property of the same ID (in this case, "DE"), then you would in fact be assigning the
+        # value of that property, not the string "DE", which is not the intention. Nevertheless, here's an example:
+        entity.addOverlay('DE', OverlayPosition.SOUTH_WEST, OverlayType.IMAGE)
 
-        # add the text of the property `exampleDynamicPropertyName` as an overlay
-        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+        # Overlays can also be used to display extra text on an entity:
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Overlay Testing")
+        entity.addOverlay('exampleDynamicPropertyName', OverlayPosition.NORTH, OverlayType.TEXT)
 
-        # add a color overlay
-        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+        # Or a small color indicator:
+        entity.addOverlay('#45e06f', OverlayPosition.NORTH_WEST, OverlayType.COLOUR)
 
-        # add a flag overlay
-        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)

--- a/demo/gunicorn/transforms/OverlayExample.py
+++ b/demo/gunicorn/transforms/OverlayExample.py
@@ -1,0 +1,30 @@
+from maltego_trx.entities import Phrase
+from maltego_trx.overlays import Position, OverlayType
+
+from maltego_trx.transform import DiscoverableTransform
+
+
+class OverlayExample(DiscoverableTransform):
+    """
+    Returns a phrase with overlays on the graph.
+    """
+
+    @classmethod
+    def create_entities(cls, request, response):
+        person_name = request.Value
+        entity = response.addEntity(Phrase, "Hi %s, nice to meet you!" % person_name)
+
+        # references the icon name `Champion` and this is will show up as an overlay on the graph
+        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+
+        # addProperty(self, fieldName=None, displayName=None, matchingRule='loose', value=None):
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+
+        # add the text of the property `exampleDynamicPropertyName` as an overlay
+        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+
+        # add a color overlay
+        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+
+        # add a flag overlay
+        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)

--- a/maltego_trx/__init__.py
+++ b/maltego_trx/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.3.7"
+VERSION = "1.3.8"

--- a/maltego_trx/entities.py
+++ b/maltego_trx/entities.py
@@ -35,3 +35,33 @@ UniqueID = "maltego.UniqueIdentifier"
 URL = "maltego.URL"
 Website = "maltego.Website"
 WebTitle = "maltego.WebTitle"
+
+# {entityName: {version2PropertyName: version3PropertyName,...}}
+entity_property_map  = {
+    "maltego.Person": {"firstname": "person.firstnames", "lastname": "person.lastname"},
+    "maltego.Domain": {"whois": "whois-info"},
+    "maltego.IPv4Address": {"whois": "whois-info"},
+    "maltego.URL": {"maltego.v2.value.property": "short-title", "theurl": "url", "fulltitle": "title"},
+    "maltego.Document": {"maltego.v2.value.property": "title", "link": "url", "metainfo": "document.meta-data"},
+    "maltego.Location": {"area": "location.area", "countrysc": "url", "long": "longitude", "lat": "latitude"},
+    "maltego.PhoneNumber": {"countrycode": "phonenumber.countrycode", "citycode": "phonenumber.citycode",
+                            "areacode": "phonenumber.areacode", "lastnumbers": "phonenumber.lastnumbers"},
+    "maltego.affiliation.Spock": {"network": "affiliation.network", "uid": "affiliation.uid",
+                                  "profile_url": "affiliation.profile-url", "spock_websites": "spock.websites"},
+    "maltego.affiliation": {"network": "affiliation.network", "uid": "affiliation.uid",
+                            "profile_url": "affiliation.profile-url"},
+    "maltego.Service": {"banner": "banner.text", "port": "port.number"},
+    "maltego.Alias": {"properties.alias": "alias"},
+    "maltego.Device": {"properties.device": "device"},
+    "maltego.GPS": {"properties.gps": "gps.coordinate"},
+    "maltego.CircularArea": {"area": "radius"},
+    "maltego.Image": {"properties.image": "description", "fullImage": "url"},
+    "maltego.NominatimLocation": {"properties.nominatimlocation": "nominatimlocation"},
+    "maltego.BuiltWithTechnology": {"properties.builtwithtechnology": "builtwith.technology"},
+    "maltego.FacebookObject": {"properties.facebookobject": "facebook.object"}
+}
+
+
+def translate_legacy_properties(entity_type, v2_property):
+    """Function maps a legacy version 2 entity property name to version 3 entity property name"""
+    return entity_property_map .get(entity_type, {}).get(v2_property)

--- a/maltego_trx/entities.py
+++ b/maltego_trx/entities.py
@@ -37,19 +37,24 @@ Website = "maltego.Website"
 WebTitle = "maltego.WebTitle"
 
 # {entityName: {version2PropertyName: version3PropertyName,...}}
-entity_property_map  = {
+entity_property_map = {
     "maltego.Person": {"firstname": "person.firstnames", "lastname": "person.lastname"},
     "maltego.Domain": {"whois": "whois-info"},
     "maltego.IPv4Address": {"whois": "whois-info"},
     "maltego.URL": {"maltego.v2.value.property": "short-title", "theurl": "url", "fulltitle": "title"},
     "maltego.Document": {"maltego.v2.value.property": "title", "link": "url", "metainfo": "document.meta-data"},
     "maltego.Location": {"area": "location.area", "countrysc": "url", "long": "longitude", "lat": "latitude"},
-    "maltego.PhoneNumber": {"countrycode": "phonenumber.countrycode", "citycode": "phonenumber.citycode",
-                            "areacode": "phonenumber.areacode", "lastnumbers": "phonenumber.lastnumbers"},
-    "maltego.affiliation.Spock": {"network": "affiliation.network", "uid": "affiliation.uid",
-                                  "profile_url": "affiliation.profile-url", "spock_websites": "spock.websites"},
-    "maltego.affiliation": {"network": "affiliation.network", "uid": "affiliation.uid",
-                            "profile_url": "affiliation.profile-url"},
+    "maltego.PhoneNumber": {
+        "countrycode": "phonenumber.countrycode", "citycode": "phonenumber.citycode",
+        "areacode": "phonenumber.areacode", "lastnumbers": "phonenumber.lastnumbers"
+    },
+    "maltego.affiliation.Spock": {
+        "network": "affiliation.network", "uid": "affiliation.uid", "profile_url": "affiliation.profile-url",
+        "spock_websites": "spock.websites"
+    },
+    "maltego.affiliation": {
+        "network": "affiliation.network", "uid": "affiliation.uid", "profile_url": "affiliation.profile-url"
+    },
     "maltego.Service": {"banner": "banner.text", "port": "port.number"},
     "maltego.Alias": {"properties.alias": "alias"},
     "maltego.Device": {"properties.device": "device"},
@@ -62,6 +67,6 @@ entity_property_map  = {
 }
 
 
-def translate_legacy_properties(entity_type, v2_property):
+def translate_legacy_property_name(entity_type, v2_property):
     """Function maps a legacy version 2 entity property name to version 3 entity property name"""
     return entity_property_map .get(entity_type, {}).get(v2_property)

--- a/maltego_trx/maltego.py
+++ b/maltego_trx/maltego.py
@@ -3,7 +3,7 @@ import uuid;
 from xml.dom import minidom
 
 from .entities import Phrase, translate_legacy_property_name, entity_property_map
-from .overlays import Position, OverlayType
+from .overlays import OverlayPosition, OverlayType
 from .utils import remove_invalid_xml_chars
 
 BOOKMARK_COLOR_NONE = "-1"
@@ -107,8 +107,10 @@ class MaltegoEntity(object):
     def setNote(self, note):
         self.addProperty('notes#', 'Notes', '', note)
 
-    def addOverlay(self, property_name=None, position=Position, overlay_type=OverlayType):
-        self.overlays.append([property_name, position.value, overlay_type.value])
+    def addOverlay(
+            self, propertyName, position: OverlayPosition, overlayType: OverlayType
+    ):
+        self.overlays.append([propertyName, position.value, overlayType.value])
 
     def add_field_to_xml(self, additional_field):
         name, display, matching, value = additional_field

--- a/maltego_trx/overlays.py
+++ b/maltego_trx/overlays.py
@@ -1,16 +1,13 @@
 from enum import Enum
 
 
-class Position(Enum):
+class OverlayPosition(Enum):
     NORTH = "N"
-    NORTH_EAST = "NE"
-    NORTH_WEST = "NW"
-    EAST = "E"
-    CENTER = "C"
-    WEST = "W"
     SOUTH = "S"
-    SOUTH_EAST = "SE"
+    WEST = "W"
+    NORTH_WEST = "NW"
     SOUTH_WEST = "SW"
+    CENTER = "C"
 
 
 class OverlayType(Enum):

--- a/maltego_trx/overlays.py
+++ b/maltego_trx/overlays.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+
+class Position(Enum):
+    NORTH = "N"
+    NORTH_EAST = "NE"
+    NORTH_WEST = "NW"
+    EAST = "E"
+    CENTER = "C"
+    WEST = "W"
+    SOUTH = "S"
+    SOUTH_EAST = "SE"
+    SOUTH_WEST = "SW"
+
+
+class OverlayType(Enum):
+    IMAGE = "image"
+    COLOUR = "colour"
+    TEXT = "text"

--- a/maltego_trx/template_dir/transforms/OverlayExample.py
+++ b/maltego_trx/template_dir/transforms/OverlayExample.py
@@ -1,5 +1,5 @@
 from maltego_trx.entities import Phrase
-from maltego_trx.overlays import Position, OverlayType
+from maltego_trx.overlays import OverlayPosition, OverlayType
 
 from maltego_trx.transform import DiscoverableTransform
 
@@ -14,17 +14,22 @@ class OverlayExample(DiscoverableTransform):
         person_name = request.Value
         entity = response.addEntity(Phrase, "Hi %s, nice to meet you!" % person_name)
 
-        # references the icon name `Champion` and this is will show up as an overlay on the graph
-        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+        # Normally, when we create an overlay, we would reference a property name so that Maltego can then use the
+        # value of that property to create the overlay. Sometimes that means creating a dynamic property, but usually
+        # it's better to either use an existing property, or, if you created the Entity yourself, and only need the
+        # property for the overlay, to use a hidden property. Here's an example of using a dynamic property:
+        entity.addProperty('dynamic_overlay_icon_name', displayName="Name for overlay image", value="Champion")
+        entity.addOverlay('dynamic_overlay_icon_name', OverlayPosition.WEST, OverlayType.IMAGE)
 
-        # addProperty(self, fieldName=None, displayName=None, matchingRule='loose', value=None):
-        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+        # You *can* also directly supply the string value of the property, however this is not recommended. Why? If
+        # the entity already has a property of the same ID (in this case, "DE"), then you would in fact be assigning the
+        # value of that property, not the string "DE", which is not the intention. Nevertheless, here's an example:
+        entity.addOverlay('DE', OverlayPosition.SOUTH_WEST, OverlayType.IMAGE)
 
-        # add the text of the property `exampleDynamicPropertyName` as an overlay
-        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+        # Overlays can also be an additional field of text displayed on the entity:
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Overlay Testing")
+        entity.addOverlay('exampleDynamicPropertyName', OverlayPosition.NORTH, OverlayType.TEXT)
 
-        # add a color overlay
-        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+        # Or a small color indicator
+        entity.addOverlay('#45e06f', OverlayPosition.NORTH_WEST, OverlayType.COLOUR)
 
-        # add a flag overlay
-        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)

--- a/maltego_trx/template_dir/transforms/OverlayExample.py
+++ b/maltego_trx/template_dir/transforms/OverlayExample.py
@@ -1,0 +1,30 @@
+from maltego_trx.entities import Phrase
+from maltego_trx.overlays import Position, OverlayType
+
+from maltego_trx.transform import DiscoverableTransform
+
+
+class OverlayExample(DiscoverableTransform):
+    """
+    Returns a phrase with overlays on the graph.
+    """
+
+    @classmethod
+    def create_entities(cls, request, response):
+        person_name = request.Value
+        entity = response.addEntity(Phrase, "Hi %s, nice to meet you!" % person_name)
+
+        # references the icon name `Champion` and this is will show up as an overlay on the graph
+        entity.addOverlay('Champion', Position.EAST, OverlayType.IMAGE)
+
+        # addProperty(self, fieldName=None, displayName=None, matchingRule='loose', value=None):
+        entity.addProperty("exampleDynamicPropertyName", "Example Dynamic Property", "loose", "Maltego Champion")
+
+        # add the text of the property `exampleDynamicPropertyName` as an overlay
+        entity.addOverlay('exampleDynamicPropertyName', Position.NORTH, OverlayType.TEXT)
+
+        # add a color overlay
+        entity.addOverlay('#45e06f', Position.NORTH_WEST, OverlayType.COLOUR)
+
+        # add a flag overlay
+        entity.addOverlay('DE', Position.SOUTH_WEST, OverlayType.IMAGE)

--- a/maltego_trx/test_hierarchical_entity.xml
+++ b/maltego_trx/test_hierarchical_entity.xml
@@ -1,0 +1,13 @@
+<Entity Type="DNSName">
+    <Genealogy>
+        <Type Name="maltego.Website" OldName="Website"/>
+        <Type Name="maltego.DNSName" OldName="DNSName"/>
+    </Genealogy>
+    <AdditionalFields>
+        <Field Name="fqdn" DisplayName="Website">www.paterva.com</Field>
+        <Field Name="website.ssl-enabled" DisplayName="SSL Enabled">false</Field>
+        <Field Name="ports" DisplayName="Ports">80</Field>
+    </AdditionalFields>
+    <Value>www.paterva.com</Value>
+    <Weight>0</Weight>
+</Entity>

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,28 @@
 from setuptools import setup
 from maltego_trx import VERSION
 
-setup(name='maltego-trx',
-      version=VERSION,
-      description='Python library used to develop Maltego transforms',
-      url='https://github.com/paterva/maltego-trx/',
-      author='Maltego Staff',
-      author_email='support@maltego.com',
-      license='MIT',
-      install_requires=[
-       'flask>=1',
-       'six>=1',
-       'cryptography>=3.3.1'
-      ],
-      packages=[
-          'maltego_trx',
-          'maltego_trx/template_dir',
-          'maltego_trx/template_dir/transforms'
-      ],
-      entry_points={'console_scripts': [
-          'maltego-trx = maltego_trx.commands:execute_from_command_line',
-      ]},
-      zip_safe=False
-      )
+setup(
+    name='maltego-trx',
+    version=VERSION,
+    description='Python library used to develop Maltego transforms',
+    url='https://github.com/paterva/maltego-trx/',
+    author='Maltego Staff',
+    author_email='support@maltego.com',
+    license='MIT',
+    install_requires=[
+        'flask>=1',
+        'six>=1',
+        'cryptography==3.3.2'  # pinned for now as newer versions require setuptools_rust
+    ],
+    packages=[
+        'maltego_trx',
+        'maltego_trx/template_dir',
+        'maltego_trx/template_dir/transforms'
+    ],
+    entry_points={
+        'console_scripts': [
+            'maltego-trx = maltego_trx.commands:execute_from_command_line',
+        ]
+    },
+    zip_safe=False
+)

--- a/tests/test_property_mapping.py
+++ b/tests/test_property_mapping.py
@@ -1,0 +1,20 @@
+from maltego_trx.registry import register_transform_classes
+from maltego_trx.server import app
+from tests import transforms
+
+
+def test_request_property_mapping():
+    register_transform_classes(transforms)
+    app.testing = True
+
+    with app.test_client() as test_app:
+        response = make_transform_call(test_app, "/run/testrequestpropertymapping/")
+        assert response.status_code == 200
+        data = response.data.decode('utf8')
+        assert "whois-info found" in data
+
+
+def make_transform_call(test_app=None, run_endpoint=""):
+    with open('test_request.xml') as requestMsg:
+        response = test_app.post(run_endpoint, data=requestMsg.read())
+    return response

--- a/tests/test_request.xml
+++ b/tests/test_request.xml
@@ -1,0 +1,18 @@
+<MaltegoMessage>
+    <MaltegoTransformRequestMessage>
+        <Entities>
+            <Entity Type="Domain">
+                <Genealogy>
+                    <Type Name="maltego.Domain" OldName="Domain"/>
+                </Genealogy>
+                <AdditionalFields>
+                    <Field Name="fqdn" DisplayName="Domain Name">paterva.com</Field>
+                    <Field Name="whois" DisplayName="Whois">whois-info found</Field>
+                </AdditionalFields>
+                <Value>paterva.com</Value>
+                <Weight>0</Weight>
+            </Entity>
+        </Entities>
+        <Limits SoftLimit="12" HardLimit="12"/>
+    </MaltegoTransformRequestMessage>
+</MaltegoMessage>

--- a/tests/transforms/TestRequestPropertyMapping.py
+++ b/tests/transforms/TestRequestPropertyMapping.py
@@ -1,0 +1,15 @@
+from maltego_trx.entities import Phrase
+
+from maltego_trx.transform import DiscoverableTransform
+
+
+class TestRequestPropertyMapping(DiscoverableTransform):
+    """
+    Test if the automatic mapping of v2 propertyname `whois` -> `whois-info` has been done by the library. Original input
+    contains only whois property name. see test_request.xml
+    """
+
+    @classmethod
+    def create_entities(cls, request, response):
+        v3_property_value = request.Properties['whois-info']
+        response.addEntity(Phrase, "%s" % v3_property_value)


### PR DESCRIPTION
This PR adds the following:

1. Method to add Overlays to an Entity
2. Defines fixed Overlay Types and Positions using an Enum to prevent modifications to abuse method
3. Add functionality to parse Genealogy from the request - this is useful when dealing with inherited Entities as the client does not send the input type. This is useful for rare cases where developers want to modify an incoming request and return it back to the Client to merge. 
4. Documentation for the above changes
5. Example Transform showing how to use overlays