### PR TITLE
Exception XML message typo: wrong closing tag

### DIFF
--- a/maltego_trx/maltego.py
+++ b/maltego_trx/maltego.py
@@ -189,7 +189,7 @@ class MaltegoTransform(object):
         lines.append("<Exceptions>")
 
         for exception in self.exceptions:
-            lines.append("<Exception>%s</Exceptions>" % remove_invalid_xml_chars(exception))
+            lines.append("<Exception>%s</Exception>" % remove_invalid_xml_chars(exception))
 
         lines.append("</Exceptions>")
         lines.append("</MaltegoTransformExceptionMessage>")


### PR DESCRIPTION
<Exception> tag was closed by </Exceptions>