### PR TITLE
sanitize message data to avoid issues with special characters in messages

### DIFF
--- a/maltego_trx/maltego.py
+++ b/maltego_trx/maltego.py
@@ -1,6 +1,7 @@
 import uuid;
 
 from xml.dom import minidom
+from xml.sax.saxutils import escape
 
 from .entities import Phrase, translate_legacy_property_name, entity_property_map
 from .overlays import OverlayPosition, OverlayType
@@ -208,7 +209,7 @@ class MaltegoTransform(object):
 
         lines.append("<UIMessages>")
         for message in self.UIMessages:
-            type, message = message
+            type, message = escape(message)
             lines.append(UIM_TEMPLATE % {"text": message, "type": type})
         lines.append("</UIMessages>")
 


### PR DESCRIPTION
Message data returned to the maltego client is not sanitized.  This creates issues when these responses contain special characters.  It seems that this issue can be mitigated simply by escaping the data prior to returning it to the client like so.

There may be additional changes required here (eg updates to the client), but realistically, all data being passed between client and server should be sanitized to avoid issues.  The escape/unescape functions (https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils.escape and https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils.unescape) should accomplish that.