### PR TITLE
fix(decorator_registry): remove typing.Literal

### DIFF
--- a/maltego_trx/decorator_registry.py
+++ b/maltego_trx/decorator_registry.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass, field
 from itertools import chain
-from typing import List, Literal, Optional, Dict, Iterable
+from typing import List, Optional, Dict, Iterable
 
 from maltego_trx.utils import filter_unique, pascal_case_to_title, escape_csv_fields, export_as_csv, serialize_bool, \
     name_to_path
@@ -26,7 +26,7 @@ class TransformMeta:
 class TransformSetting:
     name: str
     display_name: str
-    setting_type: Literal['string', 'boolean', 'date', 'datetime', 'daterange', 'url', 'double', 'int']
+    setting_type: str  # Literal['string', 'boolean', 'date', 'datetime', 'daterange', 'url', 'double', 'int']
 
     default_value: Optional[str] = ""
     optional: bool = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask>=1
+six>=1
+cryptography==3.3.2 # pinned for now as newer versions require setuptools_rust
+dataclasses==0.8; python_version < "3.7"

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ setup(
         'six>=1',
         'cryptography==3.3.2'  # pinned for now as newer versions require setuptools_rust
     ],
+    extras_require={
+        ':python_version == "3.6"': [
+            'dataclasses',
+        ],
+    },
     packages=[
         'maltego_trx',
         'maltego_trx/template_dir',


### PR DESCRIPTION
`typing.Literal` was introduced in python3.8, therefore making maltego-trx incompatible with 3.6 and 3.7. This PR will fix that.