### PR TITLE
Create @github Actions of @sonatype-nexus-community jake

### DIFF
--- a/.github/workflows/sonatype-jack.yml
+++ b/.github/workflows/sonatype-jack.yml
@@ -1,0 +1,24 @@
+name: 'Sonatype Jake'
+
+on: [push]
+
+jobs:
+  security:
+
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7.11
+    - name: Run jake from Sonatype
+      run: |
+        python -m pip install --upgrade pip
+        pip3 install -r requirements.txt
+        pip3 freeze > requirements.txt
+        pip3 install jake
+        jake ddt -r requirements.txt
+


### PR DESCRIPTION
@github Actions for https://github.com/sonatype-nexus-community/jake

The successful output of this @GitHub Actions is https://github.com/cmlh/maltego-trx-1/runs/3853289503?check_suite_focus=true

I [refroze requirements.txt](https://github.com/cmlh/maltego-trx-1/blob/cmlh-SonatypeJakeGitHubAction/.github/workflows/sonatype-jack.yml#L20-L21) as a workaround [to pin the >= packages](https://github.com/paterva/maltego-trx/blob/master/requirements.txt#L1-L2). 