### PR TITLE
fix(project.py): Import app as application for mod_wsgi compatibility

### DIFF
--- a/maltego_trx/template_dir/project.py
+++ b/maltego_trx/template_dir/project.py
@@ -4,7 +4,7 @@ import transforms
 from extensions import registry
 from maltego_trx.handler import handle_run
 from maltego_trx.registry import register_transform_classes
-from maltego_trx.server import app
+from maltego_trx.server import app as application
 
 register_transform_classes(transforms)
 
@@ -12,4 +12,4 @@ registry.write_transforms_config()
 registry.write_settings_config()
 
 if __name__ == '__main__':
-    handle_run(__name__, sys.argv + ['runserver'], app)
+    handle_run(__name__, sys.argv + ['runserver'], application)


### PR DESCRIPTION
When using the template project.py following the non dockerized apache deployment as described in the maltego docs, mod_wsgi fails, because it is expecting the app variable to be named application