### PR TITLE
fix(xml): handle None values

### DIFF
--- a/maltego_trx/utils.py
+++ b/maltego_trx/utils.py
@@ -1,6 +1,7 @@
 import math
 import re
 import sys
+import warnings
 from typing import TypeVar, Callable, Hashable, Iterable, Generator, Sequence
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
@@ -126,3 +127,18 @@ def serialize_xml(xml: Element) -> str:
         output = ElementTree.canonicalize(output)
 
     return output
+
+
+# https://stackoverflow.com/a/48632082
+def deprecated(message="This function is deprecated. Use 'make_utf8' instead."):
+    def deprecated_decorator(func):
+        def deprecated_func(*args, **kwargs):
+            warnings.warn("{} is a deprecated function. {}".format(func.__name__, message),
+                          category=DeprecationWarning,
+                          stacklevel=2)
+            warnings.simplefilter('default', DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return deprecated_func
+
+    return deprecated_decorator

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -77,3 +77,32 @@ def test_exception_message(snapshot):
     response_xml = transform_run.returnOutput()
 
     assert response_xml == snapshot
+
+
+def test_all_null_values():
+    response = MaltegoTransform()
+    entity = response.addEntity(None, None)
+    entity.addProperty(fieldName=None, displayName=None, value=None,
+                       matchingRule=None)
+
+    entity.addDisplayInformation(title=None, content=None)
+    entity.setIconURL(url=None)
+
+    entity.addOverlay(propertyName=None, position=OverlayPosition.NORTH_WEST, overlayType=OverlayType.COLOUR)
+
+    entity.setLinkLabel(None)
+    entity.setLinkThickness(None)
+    entity.setLinkColor(None)
+    entity.setLinkStyle(None)
+    entity.setType(None)
+    entity.setWeight(None)
+    entity.addCustomLinkProperty(None, None, None)
+    entity.setNote(None)
+    entity.setValue(None)
+
+    response.addUIMessage(None, messageType=None)
+    response.addException(None)
+
+    response_xml = response.returnOutput()
+
+    assert response_xml


### PR DESCRIPTION
Some forced None values could break the xml serialization. Invalid values will now be logged and ignored