### PR TITLE
Patch: properly handle null values for xml serrialization

### DIFF
--- a/maltego_trx/__init__.py
+++ b/maltego_trx/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.5.1"
+VERSION = "1.5.2"

--- a/maltego_trx/maltego.py
+++ b/maltego_trx/maltego.py
@@ -150,7 +150,8 @@ class MaltegoEntity(object):
                 title, content = display_info
 
                 if not all((title, content)):
-                    logging.warning(f"Display information is missing a title or content: {title=}, {content=}")
+                    logging.warning(f"Display information is missing a title or content: "
+                                    f"title={title}, content={content}")
                     continue
 
                 display_info_xml = SubElement(display_infos_xml, 'Label', attrib={'Name': title, 'Type': "text/html"})
@@ -164,7 +165,7 @@ class MaltegoEntity(object):
 
                 if not all((title, display, matching, val)):
                     logging.warning(f"Additional field is missing a title, display, matching or value: "
-                                    f"{title=}, {display=}, {matching=}, {val=}")
+                                    f"title={title}, display={display}, matching={matching}, val={val}")
                     continue
 
                 matching = "strict" if matching.lower().strip() == "strict" else "loose"
@@ -182,7 +183,7 @@ class MaltegoEntity(object):
 
                 if not all((property_name, position, overlay_type)):
                     logging.warning(f"Overlay is missing a property name, position or type: "
-                                    f"{property_name=}, {position=}, {overlay_type=}")
+                                    f"property_name={property_name}, position={position}, overlay_type={overlay_type}")
                     continue
 
                 SubElement(overlays_xml, 'Overlay',
@@ -243,7 +244,8 @@ class MaltegoTransform(object):
         for ui_message in self.UIMessages:
             message_type, message_content = ui_message
             if not all((message_type, message_content)):
-                logging.warning(f"UIMessage is missing a message type or content: {message_type=}, {message_content=}")
+                logging.warning(f"UIMessage is missing a message type or content: "
+                                f"message_type={message_type}, message_content={message_content}")
                 continue
 
             ui_message_xml = SubElement(ui_messages_xml, 'UIMessage', attrib={'MessageType': message_type})

--- a/maltego_trx/utils.py
+++ b/maltego_trx/utils.py
@@ -1,6 +1,7 @@
 import math
 import re
 import sys
+import warnings
 from typing import TypeVar, Callable, Hashable, Iterable, Generator, Sequence
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
@@ -126,3 +127,18 @@ def serialize_xml(xml: Element) -> str:
         output = ElementTree.canonicalize(output)
 
     return output
+
+
+# https://stackoverflow.com/a/48632082
+def deprecated(message="This function is deprecated. Use 'make_utf8' instead."):
+    def deprecated_decorator(func):
+        def deprecated_func(*args, **kwargs):
+            warnings.warn("{} is a deprecated function. {}".format(func.__name__, message),
+                          category=DeprecationWarning,
+                          stacklevel=2)
+            warnings.simplefilter('default', DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return deprecated_func
+
+    return deprecated_decorator

--- a/tests/__snapshots__/test_xml.ambr
+++ b/tests/__snapshots__/test_xml.ambr
@@ -1,15 +1,14 @@
 # name: test_all_null_values
-  '''
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=None, display=None, matching=None, val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.label, display=Label, matching=, val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.thickness, display=Thickness, matching=, val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.color, display=LinkColor, matching=, val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.style, display=LinkStyle, matching=, val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=notes#, display=Notes, matching=, val=None
-  WARNING  root:maltego.py:184 Overlay is missing a property name, position or type: property_name=None, position=NW, overlay_type=colour
-  WARNING  root:maltego.py:246 UIMessage is missing a message type or content: message_type=None, message_content=None
-  
-  '''
+  list([
+    'Additional field is missing a title, display, matching or value: title=None, display=None, matching=None, val=None',
+    'Additional field is missing a title, display, matching or value: title=link#maltego.link.label, display=Label, matching=, val=None',
+    'Additional field is missing a title, display, matching or value: title=link#maltego.link.thickness, display=Thickness, matching=, val=None',
+    'Additional field is missing a title, display, matching or value: title=link#maltego.link.color, display=LinkColor, matching=, val=None',
+    'Additional field is missing a title, display, matching or value: title=link#maltego.link.style, display=LinkStyle, matching=, val=None',
+    'Additional field is missing a title, display, matching or value: title=notes#, display=Notes, matching=, val=None',
+    'Overlay is missing a property name, position or type: property_name=None, position=NW, overlay_type=colour',
+    'UIMessage is missing a message type or content: message_type=None, message_content=None',
+  ])
 # ---
 # name: test_entity_with_display_information
   '<MaltegoMessage><MaltegoTransformResponseMessage><Entities><Entity Type="maltego.Phrase"><Value>Hello Spencer!</Value><Weight>100</Weight><DisplayInformation><Label Name="Display Info Title" Type="text/html">&lt;p&gt;Display Info Content&lt;/p&gt;</Label></DisplayInformation></Entity></Entities><UIMessages></UIMessages></MaltegoTransformResponseMessage></MaltegoMessage>'

--- a/tests/__snapshots__/test_xml.ambr
+++ b/tests/__snapshots__/test_xml.ambr
@@ -1,3 +1,16 @@
+# name: test_all_null_values
+  '''
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=None, display=None, matching=None, val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.label', display='Label', matching='', val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.thickness', display='Thickness', matching='', val='None'
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.color', display='LinkColor', matching='', val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.style', display='LinkStyle', matching='', val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='notes#', display='Notes', matching='', val=None
+  WARNING  root:maltego.py:184 Overlay is missing a property name, position or type: property_name=None, position='NW', overlay_type='colour'
+  WARNING  root:maltego.py:246 UIMessage is missing a message type or content: message_type=None, message_content=None
+  
+  '''
+# ---
 # name: test_entity_with_display_information
   '<MaltegoMessage><MaltegoTransformResponseMessage><Entities><Entity Type="maltego.Phrase"><Value>Hello Spencer!</Value><Weight>100</Weight><DisplayInformation><Label Name="Display Info Title" Type="text/html">&lt;p&gt;Display Info Content&lt;/p&gt;</Label></DisplayInformation></Entity></Entities><UIMessages></UIMessages></MaltegoTransformResponseMessage></MaltegoMessage>'
 # ---

--- a/tests/__snapshots__/test_xml.ambr
+++ b/tests/__snapshots__/test_xml.ambr
@@ -1,12 +1,12 @@
 # name: test_all_null_values
   '''
   WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=None, display=None, matching=None, val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.label', display='Label', matching='', val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.thickness', display='Thickness', matching='', val='None'
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.color', display='LinkColor', matching='', val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='link#maltego.link.style', display='LinkStyle', matching='', val=None
-  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title='notes#', display='Notes', matching='', val=None
-  WARNING  root:maltego.py:184 Overlay is missing a property name, position or type: property_name=None, position='NW', overlay_type='colour'
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.label, display=Label, matching=, val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.thickness, display=Thickness, matching=, val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.color, display=LinkColor, matching=, val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=link#maltego.link.style, display=LinkStyle, matching=, val=None
+  WARNING  root:maltego.py:166 Additional field is missing a title, display, matching or value: title=notes#, display=Notes, matching=, val=None
+  WARNING  root:maltego.py:184 Overlay is missing a property name, position or type: property_name=None, position=NW, overlay_type=colour
   WARNING  root:maltego.py:246 UIMessage is missing a message type or content: message_type=None, message_content=None
   
   '''

--- a/tests/test_property_mapping.py
+++ b/tests/test_property_mapping.py
@@ -1,7 +1,10 @@
+import os.path
+
 from maltego_trx.registry import register_transform_classes
 from maltego_trx.server import app
 from tests import transforms
 
+__TESTDIR__ = os.path.dirname(__file__)
 
 def test_request_property_mapping():
     register_transform_classes(transforms)
@@ -15,6 +18,6 @@ def test_request_property_mapping():
 
 
 def make_transform_call(test_app=None, run_endpoint=""):
-    with open('test_request.xml') as requestMsg:
+    with open(os.path.join(__TESTDIR__,'test_request.xml')) as requestMsg:
         response = test_app.post(run_endpoint, data=requestMsg.read())
     return response

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -79,7 +79,7 @@ def test_exception_message(snapshot):
     assert response_xml == snapshot
 
 
-def test_all_null_values():
+def test_all_null_values(caplog, snapshot):
     response = MaltegoTransform()
     entity = response.addEntity(None, None)
     entity.addProperty(fieldName=None, displayName=None, value=None,
@@ -104,5 +104,7 @@ def test_all_null_values():
     response.addException(None)
 
     response_xml = response.returnOutput()
-
     assert response_xml
+
+    captured = caplog.text
+    assert captured == snapshot

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -106,5 +106,5 @@ def test_all_null_values(caplog, snapshot):
     response_xml = response.returnOutput()
     assert response_xml
 
-    captured = caplog.text
+    captured = caplog.messages
     assert captured == snapshot

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -77,3 +77,32 @@ def test_exception_message(snapshot):
     response_xml = transform_run.returnOutput()
 
     assert response_xml == snapshot
+
+
+def test_all_null_values():
+    response = MaltegoTransform()
+    entity = response.addEntity(None, None)
+    entity.addProperty(fieldName=None, displayName=None, value=None,
+                       matchingRule=None)
+
+    entity.addDisplayInformation(title=None, content=None)
+    entity.setIconURL(url=None)
+
+    entity.addOverlay(propertyName=None, position=OverlayPosition.NORTH_WEST, overlayType=OverlayType.COLOUR)
+
+    entity.setLinkLabel(None)
+    entity.setLinkThickness(None)
+    entity.setLinkColor(None)
+    entity.setLinkStyle(None)
+    entity.setType(None)
+    entity.setWeight(None)
+    entity.addCustomLinkProperty(None, None, None)
+    entity.setNote(None)
+    entity.setValue(None)
+
+    response.addUIMessage(None, messageType=None)
+    response.addException(None)
+
+    response_xml = response.returnOutput()
+
+    assert response_xml


### PR DESCRIPTION
fix(test_property_mapping): use absolute path felixhertrampf 
fix(xml): use log messages only, not timestamp felixhertrampf 
fix(xml): change fstrings for py3.6 compatibility felixhertrampf 
fix(xml): check logging output felixhertrampf
fix(xml): handle None values felixhertrampf 